### PR TITLE
Fix failing CI tests due to deleted xmrto docker hub images

### DIFF
--- a/monero-harness/src/image.rs
+++ b/monero-harness/src/image.rs
@@ -25,7 +25,7 @@ impl Image for Monerod {
     type EntryPoint = str;
 
     fn descriptor(&self) -> String {
-        "xmrto/monero:v0.17.2.0".to_owned()
+        "melotools/monero:v0.17.2.0".to_owned()
     }
 
     fn wait_until_ready<D: Docker>(&self, container: &Container<'_, D, Self>) {
@@ -78,7 +78,7 @@ impl Image for MoneroWalletRpc {
     type EntryPoint = str;
 
     fn descriptor(&self) -> String {
-        "xmrto/monero:v0.17.2.0".to_owned()
+        "melotools/monero:v0.17.2.0".to_owned()
     }
 
     fn wait_until_ready<D: Docker>(&self, container: &Container<'_, D, Self>) {


### PR DESCRIPTION
Fix failing CI tests due to deleted xmrto docker hub images by moving to the docker images provided by melotools